### PR TITLE
Fix broken star history chart in READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -143,11 +143,11 @@ If you hit an issue, please open a [GitHub Issue](https://github.com/GMWalletApp
 
 ## Star History
 
-<a href="https://www.star-history.com/?type=date&repos=gmwalletapp%2Fepusdt">
+<a href="https://star-history.dera.page/#gmwalletapp/epusdt&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=gmwalletapp/epusdt&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=gmwalletapp/epusdt&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=gmwalletapp/epusdt&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=gmwalletapp%2Fepusdt&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=gmwalletapp%2Fepusdt&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=gmwalletapp%2Fepusdt&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -182,11 +182,11 @@ Epusdt 通过监听多条区块链网络（TRC20、ERC20、BEP20、Polygon 等�
 
 ## Star History
 
-<a href="https://www.star-history.com/?type=date&repos=gmwalletapp%2Fepusdt">
+<a href="https://star-history.dera.page/#gmwalletapp/epusdt&type=date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=gmwalletapp/epusdt&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=gmwalletapp/epusdt&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=gmwalletapp/epusdt&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=gmwalletapp%2Fepusdt&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=gmwalletapp%2Fepusdt&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=gmwalletapp%2Fepusdt&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in our READMEs is broken, as it relied on an API that is no longer available due to GitHub Stargazer API restrictions. The new provider uses a different data source that requires no API token. The wrapping links now use the hash-based URL format to preserve the chart options.